### PR TITLE
Fix pbtech style top index event.

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -116,7 +116,18 @@ class listener implements EventSubscriberInterface
 
 		if ($mchat_on_index && $mchat_view)
 		{
-			$this->template->assign_var('S_MCHAT_ON_INDEX', true);
+			$sql = 'SELECT style_name
+				FROM ' . STYLES_TABLE . '
+				WHERE style_id = ' . $this->user->data['user_style'];
+			$result = $this->db->sql_query($sql);
+			$row = $this->db->sql_fetchrow($result);
+
+			$this->template->assign_vars(array(
+				'S_MCHAT_ON_INDEX' => true,
+				'S_IS_NOT_PBTECH_STYLE' =>  $row['style_name'] != "PBTech" ? TRUE : FALSE,
+			));
+
+			$this->db->sql_freeresult($result);
 
 			$this->render_helper->render_data_for_page(true);
 		}

--- a/styles/pbtech/template/event/index_body_markforums_after.html
+++ b/styles/pbtech/template/event/index_body_markforums_after.html
@@ -1,0 +1,1 @@
+<!-- IF MCHAT_ENABLE and S_MCHAT_ON_INDEX and S_MCHAT_LOCATION --><!-- INCLUDE mchat_body.html --><!-- ENDIF -->

--- a/styles/prosilver/template/event/index_body_markforums_before.html
+++ b/styles/prosilver/template/event/index_body_markforums_before.html
@@ -1,1 +1,1 @@
-<!-- IF MCHAT_ENABLE and S_MCHAT_ON_INDEX and S_MCHAT_LOCATION --><!-- INCLUDE mchat_body.html --><!-- ENDIF -->
+<!-- IF MCHAT_ENABLE and S_MCHAT_ON_INDEX and S_MCHAT_LOCATION and S_IS_NOT_PBTECH_STYLE --><!-- INCLUDE mchat_body.html --><!-- ENDIF -->


### PR DESCRIPTION
Hi,
in pbtech style the event index_body_markforums_before.html is changed based on extension recent topics. When recent topics are displaying something, then this event is moved to the right side with 1/3 width. It was unbearable to read mchat in this size. So i created new template variable for check if pbtech style is present and if it is, then new event in /styles/pbtech/template/event/ kicks in and your old won't display based on new variable in listener. New looks like this:
![mchat-pbtech-fix](https://cloud.githubusercontent.com/assets/6567287/6849641/b75e0448-d3d4-11e4-8e73-21981625cce8.PNG)

The old was like: 2/3 on the left was forum categories and 1/3 on right was mchat and under it recent topics.

Regards Biosek.
