### PR TITLE
Fix reverse logic of mchat_message_top

### DIFF
--- a/adm/style/acp_mchat.html
+++ b/adm/style/acp_mchat.html
@@ -51,8 +51,8 @@
 		<dl>
 			<dt><label for="mchat_message_top">{L_MCHAT_MESSAGE_TOP}{L_COLON}</label><br />
 			<span>{L_MCHAT_MESSAGE_TOP_EXPLAIN}</span></dt>
-			<dd><label><input type="radio" class="radio" name="mchat_message_top" value="1"<!-- IF MCHAT_MESSAGE_TOP --> id="mchat_message_top" checked="checked"<!-- ENDIF --> /> {L_MCHAT_BOTTOM}</label>
-			<label><input type="radio" class="radio" name="mchat_message_top" value="0"<!-- IF not MCHAT_MESSAGE_TOP --> id="mchat_message_top" checked="checked"<!-- ENDIF --> /> {L_MCHAT_TOP}</label></dd>
+			<dd><label><input type="radio" class="radio" name="mchat_message_top" value="1"<!-- IF MCHAT_MESSAGE_TOP --> id="mchat_message_top" checked="checked"<!-- ENDIF --> /> {L_MCHAT_TOP}</label>
+			<label><input type="radio" class="radio" name="mchat_message_top" value="0"<!-- IF not MCHAT_MESSAGE_TOP --> id="mchat_message_top" checked="checked"<!-- ENDIF --> /> {L_MCHAT_BOTTOM}</label></dd>
 		</dl>
 		<dl>
 			<dt><label for="mchat_new_posts">{L_MCHAT_NEW_POSTS}{L_COLON}</label><br />

--- a/core/render_helper.php
+++ b/core/render_helper.php
@@ -427,9 +427,9 @@ class render_helper
 				$rows = $this->db->sql_fetchrowset($result);
 				$this->db->sql_freeresult($result);
 				// Reverse the array wanting messages appear in reverse
-				if($this->config['mchat_message_top'])
+				if(!$this->config['mchat_message_top'])
 				{
-				$rows = array_reverse($rows);
+					$rows = array_reverse($rows);
 				}
 
 				foreach($rows as $row)
@@ -984,9 +984,9 @@ class render_helper
 					$rows = $this->db->sql_fetchrowset($result);
 					$this->db->sql_freeresult($result);
 
-					if($this->config['mchat_message_top'])
+					if(!$this->config['mchat_message_top'])
 					{
-					$rows = array_reverse($rows, true);
+						$rows = array_reverse($rows, true);
 					}
 
 					foreach($rows as $row)

--- a/styles/prosilver/template/mchat_body.html
+++ b/styles/prosilver/template/mchat_body.html
@@ -6,9 +6,9 @@
 <!-- INCLUDEJS jquery.titlealert.min.js -->
 <!-- INCLUDEJS jquery_cookie_mini.js -->
 <!-- IF MCHAT_MESSAGE_TOP	-->
-<!-- INCLUDEJS mchat_ajax_mini.js -->
-<!-- ELSE -->
 <!-- INCLUDEJS mchat_ajax_mini_top.js -->
+<!-- ELSE -->
+<!-- INCLUDEJS mchat_ajax_mini.js -->
 <!-- ENDIF -->
 <!-- INCLUDEJS jquery-1.8.3.min.js -->
 <!-- INCLUDEJS jquery.maxlength.min.js -->


### PR DESCRIPTION
The `mchat_message_top` variable contains the wrong value, i.e. it is `true` if messages are displayed at the bottom and `false` if they are displayed at the top.
